### PR TITLE
Silence some warns

### DIFF
--- a/StringId32/Uncharted Golden Abyss/main.c
+++ b/StringId32/Uncharted Golden Abyss/main.c
@@ -59,9 +59,18 @@ U32 g_crc32Table[] = {
 
 int main(int argc, const char* Argv[])
 {
-	for( int i = 1; i < argc; i++)
+	puts("========= StringId (CRC32) generator by icemesh =========");
+	if(argc <= 0x1)
 	{
-		printf("0x%08X: %s\n", StringIdHash(Argv[i]), Argv[i] );
+		printf("%s usage: input_text ... \n", Argv[0] );
+		return 1;
+	}
+	else
+	{
+		for( int i = 1; i < argc; i++)
+		{
+			printf("%s -> 0x%08X\n", Argv[i], StringIdHash(Argv[i]) );
+		}
 	}
 	return 0;
 }

--- a/StringId32/Uncharted/main.c
+++ b/StringId32/Uncharted/main.c
@@ -68,9 +68,18 @@ const U32 StringIdHash(const char* str)
 
 int main(int argc, const char* Argv[])
 {
-	for( int i = 1; i < argc; i++)
+	puts("========= StringId (CRC32) generator by icemesh =========");
+	if(argc <= 0x1)
 	{
-		printf("0x%08X: %s\n", StringIdHash(Argv[i]), Argv[i] );
+		printf("%s usage: input_text ... \n", Argv[0] );
+		return 1;
+	}
+	else
+	{
+		for( int i = 1; i < argc; i++)
+		{
+			printf("%s -> 0x%08X\n", Argv[i], StringIdHash(Argv[i]) );
+		}
 	}
 	return 0;
 }

--- a/StringId64/main.c
+++ b/StringId64/main.c
@@ -11,15 +11,21 @@ inline uint64_t ToStringId64(const char* str);
 
 int main(int argc, const char* aArgv[])
 {
+	puts("========= StringId (FNV-1a) generator by icemesh =========");
 	if(argc <= 0x1)
 	{
-		 return 0;
+		printf("%s usage: input_text ... \n", aArgv[0] );
+		return 1;
 	}
 	else
 	{
 		for( int i = 1; i < argc; i++)
 		{
-			printf("#%.16llX -> %s\n", ToStringId64(aArgv[i]), aArgv[i] );
+#ifdef __WIN32__
+			printf("%s -> #%.16llX\n",aArgv[i] ,ToStringId64(aArgv[i]) );
+#else
+			printf("%s -> #%.16lX\n",aArgv[i] ,ToStringId64(aArgv[i]) );
+#endif
 		}
 		return 0;
 	}


### PR DESCRIPTION
Also reverse string output order, we are converting from one data to another, better to be `src -> dest`

```
clang main.c -o a
main.c:22:31: warning: format specifies type 'unsigned long long' but the argument has type 'uint64_t' (aka 'unsigned long') [-Wformat]
                        printf("#%.16llX -> %s\n", ToStringId64(aArgv[i]), aArgv[i] );
                                 ~~~~~~~           ^~~~~~~~~~~~~~~~~~~~~~
                                 %.16lX
```
